### PR TITLE
Make it impossible to join as non-mapped jobs

### DIFF
--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -122,8 +122,8 @@ Curator
 	department_head = list("Head of Personnel")
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 
@@ -168,8 +168,8 @@ Lawyer
 	department_head = list("Head of Personnel")
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	var/lawyers = 0 //Counts lawyer amount

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -8,8 +8,8 @@ Chaplain
 	department_head = list("Head of Personnel")
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	description = "As a counselor you are responsible for hearing the crew's troubles and ensuring the dead are buried properly. This role is extremely important burials allow crew to respawn."

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -147,8 +147,8 @@ Geneticist
 	department_head = list("Chief Medical Officer", "Research Director")
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the chief medical officer and research director"
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW
@@ -186,8 +186,8 @@ Virologist
 	department_head = list("Chief Medical Officer")
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
 	exp_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -109,8 +109,8 @@ Roboticist
 	department_head = list("Research Director")
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
 	exp_requirements = 60

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -139,8 +139,8 @@ Detective
 	department_head = list("Head of Security")
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -22,24 +22,24 @@ Janitor=2,1
 
 Clown=1,1
 Mime=1,1
-Curator=1,1
-Lawyer=2,2
+Curator=0,0
+Lawyer=0,0
 
-Chaplain=1,1
+Chaplain=0,0
 
 Station Engineer=5,5
 Atmospheric Technician=3,2
 
 Medical Doctor=5,3
 Chemist=2,2
-Geneticist=2,2
-Virologist=1,1
+Geneticist=0,0
+Virologist=0,0
 
 Scientist=5,3
-Roboticist=2,2
+Roboticist=0,0
 
 Warden=1,1
-Detective=1,1
+Detective=0,0
 Security Officer=5,5
 
 AI=0,1


### PR DESCRIPTION
Affected jobs: Roboticist, Geneticist, Virologist, Curator, Lawyer, Counselor, Detective

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl:
config: Now impossible to join as: Roboticist, Geneticist, Virologist, Curator, Lawyer, Counselor, Detective
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
