### PR TITLE
Remove option to download pre-compiled nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ code tab of https://github.com/DDMers/Deep-Space-13
 (note: this will use a lot of bandwidth if you wish to update and is a lot of
 hassle if you want to make any changes at all, so it's not recommended.)
 
-Option 3: Download a pre-compiled nightly at https://tgstation13.download/nightlies/ (same caveats as option 2)
-
-Option 4: Use our docker image that tracks the master branch (See commits for build status. Again, same caveats as option 2)
+Option 3: Use our docker image that tracks the master branch (See commits for build status. Again, same caveats as option 2)
 
 ```
 docker run -d -p <your port>:1337 -v /path/to/your/config:/tgstation/config -v /path/to/your/data:/tgstation/data tgstation/tgstation <dream daemon options i.e. -public or -params>


### PR DESCRIPTION
[why]: tgstation does not offer pre-compiled Deep Space 13 builds.