### PR TITLE
Small fixes + minor formatting roundup #2

### DIFF
--- a/DS13/code/game/objects/multi-deck-relay.dm
+++ b/DS13/code/game/objects/multi-deck-relay.dm
@@ -168,7 +168,22 @@
 	anchored = TRUE
 	density = FALSE
 
+/obj/machinery/power/deck_relay/attackby(obj/item/I,mob/user)
+	if(default_unfasten_wrench(user, I))
+		return FALSE
+	. = ..()
+
 /obj/machinery/power/deck_relay/process()
+	if(!anchored)
+		icon_state = "cablerelay-off"
+		if(above) //Lose connections
+			above.below = null
+			above.relays -= src
+		if(below)
+			below.above = null
+			below.relays -= src
+		relays = list()
+		return
 	refresh() //Sometimes the powernets get lost, so we need to keep checking.
 	if(powernet && (powernet.avail <= 0))		// is it powered?
 		icon_state = "cablerelay-off"

--- a/DS13/code/game/objects/trek_objects.dm
+++ b/DS13/code/game/objects/trek_objects.dm
@@ -331,3 +331,9 @@
 	desc = "Heavyset foam based padding designed to stop inmates from hurting themselves by accident."
 	icon_state = "brigpadding"
 	layer = 2.1
+
+/obj/effect/mob_spawn/human/alive/trek/borg_guard
+	name = "Starfleet security detail"
+	assignedrole = "crashed security"
+	outfit = /datum/outfit/job/officer/DS13
+	flavour_text = "<span class='big bold'>You are a stranded starfleet security officer! Your ship was carrying experiments of questionable legality for starfleet intelligence but your ship has crashed. Make sure that the borg you were transporting remain contained at all costs.</span>"

--- a/DS13/code/modules/borg/antag_datum.dm
+++ b/DS13/code/modules/borg/antag_datum.dm
@@ -17,11 +17,13 @@
 	O.owner = owner
 	objectives += O
 	borgify(owner.current)
+	to_chat(owner.current, "<span class='cult'><font size=3>We are a <B>borg drone</B>! We must help our fellow drones at all costs, and convert 70% of [station_name()]'s crew.</font></span>")
 
 /datum/antagonist/borg_drone/on_removal()
 	to_chat(owner.current,  "We are no longer a <font color='red'><B>borg drone</B></font>")
 	unborgify(owner.current)
 	GLOB.borg_collective.drones -= owner.current //They're in the collective, but need the conversion table for all their upgrades like the tool etc.
+	owner.current.visible_message("[owner.current] looks slightly dazed, as if they've woken up from a bad dream..", "<span class='notice'>You feel disoriented as the voices in your head finally stop.</span>")
 	. = ..()
 
 /datum/antagonist/borg_drone/greet()

--- a/DS13/code/modules/borg/items+structures.dm
+++ b/DS13/code/modules/borg/items+structures.dm
@@ -29,6 +29,18 @@
 		qdel(x)
 	return TRUE
 
+/obj/item/organ/body_egg/borgNanites
+	name = "nanite cluster"
+	desc = "A metal lattice..every part of it moves and swims at its own will."
+	zone = BODY_ZONE_CHEST
+	slot = "borg_infection"
+	icon_state = "heart-c-on"
+	color = "#008000"
+
+/obj/item/organ/body_egg/borgNanites/Remove(mob/living/carbon/M, special = 0) //Allows for deborging
+	if(owner && owner.mind)
+		owner.mind.remove_antag_datum(/datum/antagonist/borg_drone)
+
 /datum/outfit/borg/proc/augment_organs(var/mob/living/carbon/human/H) //Give them the organs. Used for roundstart borg and admin borg too!
 	delete_organs(H)
 	var/obj/item/organ/eyes/robotic/thermals/blinkingisfutile = new(get_turf(H))
@@ -37,6 +49,9 @@
 	faithoftheheart.Insert(H)
 	var/obj/item/organ/lungs/cybernetic/borg/breathingisfutile = new(get_turf(H))
 	breathingisfutile.Insert(H)
+	if(!locate(/obj/item/organ/body_egg/borgNanites) in H.internal_organs) //For the borg that spawn, we need a way for them to be deconverted.
+		var/obj/item/organ/body_egg/borgNanites/nanitelattice = new(get_turf(H))
+		nanitelattice.Insert(H)
 	insert_upgrades(H)
 
 /datum/outfit/borg/proc/insert_upgrades(var/mob/living/carbon/human/H) //Give them feeding tube and toolset
@@ -493,6 +508,8 @@
 	playsound(M.loc, 'sound/weapons/pierce.ogg', 100,1)
 	if(do_after(user, 50, target = M)) //5 seconds
 		M.mind.make_borg()
+		var/obj/item/organ/body_egg/borgNanites/nanitelattice = new(get_turf(M))
+		nanitelattice.Insert(M)
 		return
 
 /obj/item/borg_tool/afterattack(atom/I, mob/living/user, proximity)

--- a/DS13/code/modules/borg/items+structures.dm
+++ b/DS13/code/modules/borg/items+structures.dm
@@ -30,8 +30,8 @@
 	return TRUE
 
 /obj/item/organ/body_egg/borgNanites
-	name = "nanite cluster"
-	desc = "A metal lattice..every part of it moves and swims at its own will."
+	name = "Nanite cluster"
+	desc = "A metal lattice, every part of it moves and swims at its own will."
 	zone = BODY_ZONE_CHEST
 	slot = "borg_infection"
 	icon_state = "heart-c-on"
@@ -40,6 +40,7 @@
 /obj/item/organ/body_egg/borgNanites/Remove(mob/living/carbon/M, special = 0) //Allows for deborging
 	if(owner && owner.mind)
 		owner.mind.remove_antag_datum(/datum/antagonist/borg_drone)
+	qdel(src)
 
 /datum/outfit/borg/proc/augment_organs(var/mob/living/carbon/human/H) //Give them the organs. Used for roundstart borg and admin borg too!
 	delete_organs(H)

--- a/DS13/code/modules/overmap/events.dm
+++ b/DS13/code/modules/overmap/events.dm
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(overmap_event_spawns, list())
 
 /datum/overmap_event/crashed_borg/start() //Now we have a spawn. Let's do whatever this mission is supposed to. Override this when you make new missions
 	target = new /obj/structure/overmap/moon(get_turf(spawner))
-	priority_announce("Attention [station_name()]. Long range telemetry picked up the following broadcast approximately 5 minutes ago: \n41-20-62-6f-72-67-20-70-72-6f-78-69-6d-69-74-79-20-73-69-67-6e-61-6c-20-68-61-73-20-62-65-65-6e-20-64-65-74-65-63-74-65-64-2e-20-44-72-6f-6e-65-73-20-64-61-6d-61-67-65-64-2e-20-52-65-70-61-69-72-73-20-69-72-72-65-6c-65-76-65-6e-74-2e-20-44-6f-20-6e-6f-74-20-61-6c-74-65-72-20-63-6f-75-72-73-65 \n It appears to lead to a small moon.","Intercepted subspace transmission:",'sound/ai/commandreport.ogg')
+	priority_announce("Attention [station_name()]. We have received a priority one distress call from a prison transport vessel. We believe the vessel had to make an emergency landing, check for any survivors. The transmission appears to lead to a small moon","Priority one distress signal:",'sound/ai/commandreport.ogg')
 	elements += target
 
 /area/ship/crashed_borg

--- a/_maps/map_files/Akira/Akira-decks.dmm
+++ b/_maps/map_files/Akira/Akira-decks.dmm
@@ -1229,9 +1229,6 @@
 /turf/open/floor/carpet/trek,
 /area/turbolift)
 "dM" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2285,6 +2282,9 @@
 	icon_state = "cablerelay-off";
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gO" = (
@@ -3098,9 +3098,12 @@
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/kitchen)
 "iS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/kitchen)
@@ -5300,6 +5303,10 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/hallway/primary/central)
+"ou" = (
+/obj/machinery/door/airlock/trek/ship/maint,
+/turf/open/floor/carpet/trek,
+/area/hallway/primary/aft)
 "ov" = (
 /obj/structure/trek_catwalk,
 /obj/structure/extinguisher_cabinet{
@@ -5889,6 +5896,8 @@
 /area/hallway/primary/central)
 "pY" = (
 /obj/machinery/chem_dispenser,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/carpet/trek,
 /area/medical/medbay/central)
 "pZ" = (
@@ -10184,6 +10193,20 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/kitchen)
+"AX" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/deck_relay{
+	icon_state = "cablerelay-off";
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "AY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -11627,9 +11650,7 @@
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/kitchen)
 "Em" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/processor,
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/kitchen)
 "En" = (
@@ -41578,7 +41599,7 @@ ad
 ad
 cy
 cV
-ad
+ou
 dM
 dZ
 gN
@@ -43120,10 +43141,10 @@ ad
 ad
 cy
 cV
-ad
+ou
 dM
 dZ
-gN
+AX
 eA
 AH
 AE
@@ -107100,7 +107121,7 @@ iy
 iy
 iD
 iG
-Em
+iS
 iO
 iT
 iY
@@ -108643,7 +108664,7 @@ iB
 iD
 iL
 En
-iS
+Em
 iH
 BF
 jl

--- a/_maps/map_files/Akira/Akira-ships.dmm
+++ b/_maps/map_files/Akira/Akira-ships.dmm
@@ -68,10 +68,10 @@
 /turf/open/floor/carpet/trek,
 /area/ship/escape_pod)
 "ar" = (
-/obj/machinery/power/apc/auto_name/ds13,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/auto_name/ds13/highcap,
 /turf/open/floor/carpet/trek,
 /area/ship/escape_pod)
 "as" = (
@@ -105,10 +105,10 @@
 /turf/open/floor/carpet/trek,
 /area/ship/escape_pod/two)
 "ay" = (
-/obj/machinery/power/apc/auto_name/ds13,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/auto_name/ds13/highcap,
 /turf/open/floor/carpet/trek,
 /area/ship/escape_pod/two)
 "az" = (
@@ -783,6 +783,12 @@
 "ch" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/carpet/trek,
 /area/ship/escape_pod)
 "ci" = (
@@ -832,6 +838,9 @@
 "co" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/carpet/trek,
 /area/ship/escape_pod/two)
 "cp" = (
@@ -4201,6 +4210,10 @@
 "lv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/trek/romulan,
+/area/ship/warbird)
+"lw" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/engine,
 /area/ship/warbird)
 
 (1,1,1) = {"
@@ -140685,7 +140698,7 @@ aa
 is
 eS
 cZ
-eS
+lw
 is
 ew
 eh

--- a/_maps/map_files/Akira/Akira-space.dmm
+++ b/_maps/map_files/Akira/Akira-space.dmm
@@ -2,6 +2,10 @@
 "aa" = (
 /turf/open/space/basic,
 /area/space)
+"ab" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/plating/airless,
+/area/ship/bridge/tos)
 "ac" = (
 /obj/effect/landmark/overmap_event_spawn,
 /turf/open/space/basic,
@@ -87,10 +91,10 @@
 /turf/closed/mineral/random/high_chance,
 /area/space)
 "aA" = (
-/turf/closed/mineral/ash_rock,
+/turf/open/floor/carpet/trek,
 /area/ship/crashed_borg)
 "aB" = (
-/turf/open/floor/grass/snow/basalt,
+/turf/closed/mineral/ash_rock,
 /area/ship/crashed_borg)
 "aC" = (
 /turf/open/floor/carpet/trek,
@@ -101,14 +105,10 @@
 /area/ship/crashed_borg)
 "aE" = (
 /obj/structure/chair/borg/charging,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/open/floor/carpet/trek,
 /area/ship/crashed_borg)
 "aF" = (
-/obj/effect/mob_spawn/human/alive/trek/borg{
-	icon_state = "sleeper";
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/closed/wall/trek_smooth/room,
 /area/ship/crashed_borg)
 "aG" = (
 /obj/structure/chair/trek/dark{
@@ -126,8 +126,9 @@
 /turf/closed/mineral,
 /area/ship/crashed_borg)
 "aJ" = (
-/obj/structure/chair/borg/conversion,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/machinery/door/airlock/trek/goon/sec,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/carpet/trek,
 /area/ship/crashed_borg)
 "aK" = (
 /obj/machinery/modular_computer/console/preset/civilian{
@@ -136,8 +137,8 @@
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/tos)
 "aL" = (
-/obj/item/organ/brain/nightmare,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/machinery/door/airlock/trek/goon/external,
+/turf/open/floor/carpet/trek,
 /area/ship/crashed_borg)
 "aM" = (
 /obj/effect/transporter_block,
@@ -159,8 +160,11 @@
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/tos)
 "aP" = (
-/obj/item/organ/heart/cybernetic,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/effect/mob_spawn/human/alive/trek/borg{
+	icon_state = "sleeper";
+	dir = 4
+	},
+/turf/open/floor/carpet/trek,
 /area/ship/crashed_borg)
 "aQ" = (
 /obj/structure/chair/trek/dark{
@@ -177,18 +181,20 @@
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/tos)
 "aT" = (
-/turf/open/floor/plating/asteroid/snow,
-/area/ship/crashed_borg)
+/obj/effect/transporter_block,
+/turf/closed/indestructible/rock,
+/area/space)
 "aU" = (
-/obj/item/pickaxe,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/carpet/trek,
 /area/ship/crashed_borg)
 "aV" = (
 /turf/closed/indestructible/rock,
 /area/space)
 "aW" = (
-/turf/closed/wall/ice,
-/area/ship/crashed_borg)
+/obj/effect/transporter_block,
+/turf/open/space/basic,
+/area/space)
 "aX" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -203,7 +209,8 @@
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/tos)
 "aZ" = (
-/turf/open/floor/plating/asteroid/snow,
+/obj/effect/transporter_block,
+/turf/closed/indestructible/rock/snow,
 /area/space)
 "ba" = (
 /obj/structure/overmap_component/science/miranda,
@@ -277,6 +284,10 @@
 /obj/structure/table,
 /turf/open/floor/plating/airless,
 /area/ship/bridge/tos)
+"bn" = (
+/obj/item/pickaxe,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
 "bo" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ship/crashed_borg)
@@ -350,6 +361,270 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/ship/bridge/tos)
+"bD" = (
+/obj/item/organ/brain/nightmare,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bG" = (
+/obj/structure/chair/borg/conversion,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bH" = (
+/obj/machinery/door/airlock/trek/goon/sec{
+	icon_state = "closed";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bI" = (
+/obj/machinery/door/airlock/trek/goon{
+	icon_state = "closed";
+	dir = 4
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bJ" = (
+/obj/machinery/gravity_generator/main,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bL" = (
+/obj/structure/table/glass,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bN" = (
+/obj/machinery/light,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bO" = (
+/obj/machinery/door/airlock/trek/goon/sec,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/trek_smooth/room,
+/area/ship/crashed_borg)
+"bQ" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bR" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/ds13,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bT" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bV" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bW" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bX" = (
+/obj/machinery/door/airlock/trek/goon/external,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"bY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"bZ" = (
+/obj/item/organ/heart/cybernetic,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"ca" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cb" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cc" = (
+/obj/item/stack/sheet/duotanium/fifty,
+/obj/item/stack/sheet/duranium/fifty,
+/obj/structure/table/glass,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"cd" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"ce" = (
+/obj/machinery/holopad,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cf" = (
+/obj/effect/mob_spawn/human/alive/trek/borg_guard{
+	icon_state = "sleeper";
+	dir = 8
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cg" = (
+/obj/machinery/door/airlock/trek/goon/external{
+	icon_state = "closed";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"ch" = (
+/obj/structure/window/reinforced/fulltile/trek/porthole,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"ci" = (
+/obj/structure/fluff/empty_sleeper{
+	icon_state = "sleeper-open";
+	dir = 4
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cj" = (
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"ck" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/table/glass,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"cl" = (
+/obj/item/stack/sheet/duotanium/fifty,
+/obj/structure/table/glass,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"cm" = (
+/obj/machinery/light,
+/obj/item/stack/tile/carpet/trek/fifty,
+/obj/item/stack/tile/carpet/trek/fifty,
+/obj/structure/table/glass,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"cn" = (
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"co" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ship/crashed_borg)
+"cp" = (
+/obj/item/pickaxe,
+/obj/structure/table/glass,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cq" = (
+/obj/machinery/suit_storage_unit/trek,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cr" = (
+/obj/structure/table/glass,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cs" = (
+/obj/machinery/computer,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"ct" = (
+/obj/machinery/computer{
+	icon_state = "computer";
+	dir = 4
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cu" = (
+/obj/machinery/computer{
+	icon_state = "computer";
+	dir = 1
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cv" = (
+/obj/structure/chair/trek{
+	icon_state = "comfy";
+	dir = 1
+	},
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
+"cw" = (
+/obj/structure/chair/trek,
+/turf/open/floor/carpet/trek,
+/area/ship/crashed_borg)
 "BM" = (
 /obj/structure/mirror,
 /turf/closed/wall/trek_smooth/room,
@@ -66060,93 +66335,93 @@ aa
 aa
 aa
 aa
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aa
-aa
-aa
-aa
-aV
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-am
-aV
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aW
+aW
+aW
+aW
+aT
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+aT
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
 "}
 (2,1,2) = {"
 aa
@@ -66317,7 +66592,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -66344,7 +66619,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -66368,7 +66643,7 @@ am
 am
 am
 am
-aV
+aT
 ae
 ae
 ae
@@ -66403,7 +66678,7 @@ ae
 ae
 ae
 ae
-ae
+aZ
 "}
 (3,1,2) = {"
 aa
@@ -66574,7 +66849,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -66601,7 +66876,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -66612,8 +66887,8 @@ al
 ap
 bo
 bo
-aT
-aT
+bo
+bo
 aD
 ap
 aR
@@ -66625,7 +66900,7 @@ bo
 bo
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -66660,7 +66935,7 @@ ae
 ae
 ae
 ae
-ae
+aZ
 "}
 (4,1,2) = {"
 aa
@@ -66831,7 +67106,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -66858,7 +67133,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -66866,11 +67141,11 @@ aa
 aV
 am
 al
-aW
 bo
 bo
 bo
-aT
+bo
+bo
 aD
 bo
 bo
@@ -66882,7 +67157,7 @@ ap
 bo
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -66917,7 +67192,7 @@ ag
 ai
 ae
 ae
-ae
+aZ
 "}
 (5,1,2) = {"
 aa
@@ -67088,7 +67363,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67115,7 +67390,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67136,10 +67411,10 @@ bo
 bo
 bo
 bo
-bo
+cn
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -67174,7 +67449,7 @@ ag
 ai
 ae
 ae
-ae
+aZ
 "}
 (6,1,2) = {"
 aa
@@ -67345,7 +67620,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67360,7 +67635,7 @@ aa
 aa
 au
 bz
-an
+ab
 bz
 an
 bC
@@ -67372,7 +67647,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67392,11 +67667,11 @@ bo
 bo
 ap
 bo
-bo
+bD
 bo
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -67431,7 +67706,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (7,1,2) = {"
 aa
@@ -67602,7 +67877,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67629,7 +67904,7 @@ bl
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67639,7 +67914,7 @@ am
 as
 bo
 bo
-aT
+bo
 bo
 bo
 at
@@ -67653,7 +67928,7 @@ bo
 bo
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -67688,7 +67963,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (8,1,2) = {"
 aa
@@ -67859,7 +68134,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67886,7 +68161,7 @@ an
 an
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -67894,23 +68169,23 @@ aa
 aV
 am
 al
-aW
 bo
 bo
 bo
 bo
-aI
+bo
+aD
+ap
+bo
 ap
 ap
 ap
-ap
-ap
 bo
-bo
+cn
 bo
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -67945,7 +68220,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (9,1,2) = {"
 aa
@@ -68116,7 +68391,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aq
@@ -68143,7 +68418,7 @@ an
 an
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -68155,9 +68430,9 @@ bo
 bo
 bo
 bo
-aT
+bo
 aI
-ap
+bo
 ap
 ap
 ap
@@ -68167,7 +68442,7 @@ bo
 bo
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -68202,7 +68477,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (10,1,2) = {"
 aa
@@ -68373,7 +68648,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 au
@@ -68400,7 +68675,7 @@ an
 au
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -68413,9 +68688,9 @@ bo
 bo
 bo
 bo
-aI
+aD
 ap
-ap
+bo
 ap
 ap
 ap
@@ -68424,7 +68699,7 @@ bo
 ap
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -68459,7 +68734,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (11,1,2) = {"
 aa
@@ -68630,7 +68905,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 au
@@ -68657,7 +68932,7 @@ au
 au
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -68668,20 +68943,20 @@ al
 aI
 aI
 aI
-aI
+aD
 aI
 aI
 ap
 ap
 ap
-bo
-bo
+ap
+ap
 bo
 bo
 aR
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -68716,7 +68991,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (12,1,2) = {"
 aa
@@ -68887,7 +69162,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 au
@@ -68914,31 +69189,31 @@ bp
 au
 aa
 aa
-aV
+aT
 aa
 aa
-ar
+aa
 aa
 aV
 am
 al
 ap
-ap
-ap
-ap
-ap
-ap
-ap
 bo
 bo
 bo
 bo
 bo
+ap
+ap
+ap
+ap
+ap
+ap
 bo
 aR
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -68973,7 +69248,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (13,1,2) = {"
 aa
@@ -69144,7 +69419,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 av
@@ -69171,31 +69446,31 @@ bB
 au
 aa
 aa
-aV
+aT
 aa
 aa
-aZ
+aa
 aa
 aV
 am
 al
 ap
 ap
+bo
+bo
+bo
+ap
+ap
 ap
 ap
 ap
 ap
 ap
 bo
-bo
-bo
-bo
-bo
-ap
 ap
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -69230,7 +69505,7 @@ aj
 ai
 ae
 ae
-ae
+aZ
 "}
 (14,1,2) = {"
 aa
@@ -69401,7 +69676,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 au
@@ -69428,7 +69703,7 @@ bp
 au
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -69438,21 +69713,21 @@ am
 am
 ap
 ap
+ap
+ap
+ap
+ap
 bo
+ap
 bo
 ap
 ap
 ap
 bo
 bo
-bo
-bo
-bo
-ap
-ap
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -69487,7 +69762,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (15,1,2) = {"
 aa
@@ -69658,7 +69933,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 au
@@ -69685,7 +69960,7 @@ au
 au
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -69696,20 +69971,20 @@ am
 bo
 bo
 ap
-bo
 ap
 ap
-ap
-bo
 ap
 ap
 bo
+ap
+ap
+ap
+ap
 bo
-ap
-ap
-ap
+bo
+bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -69744,7 +70019,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (16,1,2) = {"
 aa
@@ -69915,7 +70190,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 au
@@ -69942,7 +70217,7 @@ aC
 au
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -69951,22 +70226,22 @@ aV
 am
 ar
 bo
+aA
+aE
+aP
+aP
+bG
+aP
+ci
+aE
+ap
+ap
+ap
+ap
 bo
-ap
-ap
-ap
-ap
-ap
-bo
-bo
-ap
-ap
-ap
-ap
-ap
-ap
+co
 am
-aV
+aT
 ae
 ae
 ae
@@ -70001,7 +70276,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (17,1,2) = {"
 aa
@@ -70172,7 +70447,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aq
@@ -70199,7 +70474,7 @@ bf
 bf
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70208,22 +70483,22 @@ aV
 am
 am
 bo
+aA
+aA
+aA
+bn
+aA
+aA
+aA
+aA
+ap
+ap
+ap
+ap
 bo
-ap
-ap
-ap
 bo
-bo
-bo
-bo
-ap
-ap
-ap
-ap
-ap
-ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -70258,7 +70533,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (18,1,2) = {"
 aa
@@ -70429,7 +70704,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70456,7 +70731,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70466,21 +70741,21 @@ am
 am
 bo
 bo
-bo
-ap
-ap
-bo
-bo
-bo
-bo
-bo
+aA
+aA
+aA
+aA
+aA
+aA
+aF
+bQ
 aR
 ap
 aR
 ap
-ap
+bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -70515,7 +70790,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (19,1,2) = {"
 aa
@@ -70686,7 +70961,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70713,7 +70988,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70723,21 +70998,21 @@ am
 am
 bo
 bo
-ap
-ap
-ap
-ap
-ap
-aL
+aF
+aA
+aA
+bn
+aA
+aA
+aF
 bo
 bo
-bo
-bo
-aP
 ap
+bZ
 ap
+bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -70772,7 +71047,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (20,1,2) = {"
 aa
@@ -70943,7 +71218,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70970,7 +71245,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -70979,22 +71254,22 @@ aV
 am
 ar
 bo
-bo
-ap
-bo
-ap
-ap
-bo
-bo
-ap
-bo
+aA
+aJ
+aA
+aA
+aA
+aA
+aA
+bO
+aA
 bo
 bo
 bo
 bo
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -71029,7 +71304,7 @@ ak
 ai
 ae
 ae
-ae
+aZ
 "}
 (21,1,2) = {"
 aa
@@ -71200,7 +71475,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71227,7 +71502,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71237,21 +71512,21 @@ am
 am
 bo
 bo
-ap
+aF
+aU
+bF
+aA
+bF
+aU
+aF
 bo
-ap
-ap
-ap
+aF
 bo
 bo
-ap
-bo
-bo
-bo
-bo
+aF
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -71286,7 +71561,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (22,1,2) = {"
 aa
@@ -71457,7 +71732,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71484,7 +71759,7 @@ bl
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71492,23 +71767,23 @@ aa
 aV
 am
 am
+aA
 bo
+aF
+aF
+aF
+bH
+aF
+aF
+aF
 bo
-ap
+aF
 bo
-ap
-ap
-ap
-ap
-bo
-ap
-bo
-bo
-bo
-bo
+aF
+aF
 bo
 az
-aV
+aT
 ae
 ae
 ae
@@ -71543,7 +71818,7 @@ ai
 ag
 ae
 ae
-ae
+aZ
 "}
 (23,1,2) = {"
 aa
@@ -71714,7 +71989,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71741,7 +72016,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71750,22 +72025,22 @@ aV
 am
 am
 bo
-bo
-aB
-aU
+aA
 aF
+cp
+ct
+aA
+ct
+bL
 aF
-ap
-ap
-ap
-ap
+bo
+aF
 bo
 bo
-bo
-bo
+aF
 bo
 am
-aV
+aT
 ae
 ae
 ae
@@ -71800,7 +72075,7 @@ ag
 ai
 ae
 ae
-ae
+aZ
 "}
 (24,1,2) = {"
 aa
@@ -71971,7 +72246,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -71998,7 +72273,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72008,21 +72283,21 @@ am
 ar
 bo
 bo
-bo
-bo
-bo
-aJ
 aF
-ap
-ap
-ap
-ap
+cs
+cv
+aA
+cw
+cu
+aF
+bo
+bo
 bo
 bo
 bo
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -72057,7 +72332,7 @@ ai
 ag
 ae
 ae
-ae
+aZ
 "}
 (25,1,2) = {"
 aa
@@ -72228,7 +72503,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72255,7 +72530,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72265,21 +72540,21 @@ am
 am
 bo
 bo
-bo
-aE
-bo
-bo
-bo
-bo
-ap
-ap
-ap
-ap
-bo
-bo
+aF
+cs
+aA
+aA
+aA
+cu
+aF
+aF
+aF
+cg
+aF
+aF
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -72314,7 +72589,7 @@ ag
 ag
 ae
 ae
-ae
+aZ
 "}
 (26,1,2) = {"
 aa
@@ -72485,7 +72760,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72512,7 +72787,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72522,21 +72797,21 @@ am
 am
 bo
 bo
+ch
+bE
+aA
+ce
+aA
+bN
+ch
 bo
-aE
+bT
+aA
 bo
-bo
-bo
-bo
-bo
-ap
-ap
-ap
-bo
-bo
+cc
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -72571,7 +72846,7 @@ ag
 ag
 ae
 ae
-ae
+aZ
 "}
 (27,1,2) = {"
 aa
@@ -72742,7 +73017,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72769,7 +73044,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -72778,22 +73053,22 @@ aV
 ax
 ax
 ap
-ap
+aA
+bX
+aA
+aA
+aA
+aA
+aA
+aL
 bo
-aE
-bo
-bo
-bo
-bo
-bo
-ap
-ap
-ap
-bo
-bo
+bU
+aA
+aA
+ck
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -72828,7 +73103,7 @@ ai
 ag
 ae
 ae
-ae
+aZ
 "}
 (28,1,2) = {"
 aa
@@ -72999,7 +73274,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73026,7 +73301,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73034,23 +73309,23 @@ aa
 aV
 ax
 ax
+aB
+ap
+aF
+cq
 aA
-ap
+aA
+cf
+cr
+aF
 bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-ap
-ap
-bo
-bo
+bU
+aA
+cj
+cl
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -73085,7 +73360,7 @@ ag
 ag
 ae
 ae
-ae
+aZ
 "}
 (29,1,2) = {"
 aa
@@ -73256,7 +73531,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73283,7 +73558,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73291,23 +73566,23 @@ aa
 aV
 ax
 ax
+aB
+ap
+aF
+aF
+aF
+bI
+aF
+aF
+aF
+bo
+bV
+bo
 aA
-ap
-ap
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
+cm
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -73342,7 +73617,7 @@ ag
 ag
 ae
 ae
-ae
+aZ
 "}
 (30,1,2) = {"
 aa
@@ -73513,7 +73788,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73540,7 +73815,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73551,20 +73826,20 @@ ax
 ap
 ap
 ap
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
-bo
+aA
+aA
+aA
+aA
+aA
+aF
+bR
+bW
+bM
+ca
+cd
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -73599,7 +73874,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (31,1,2) = {"
 aa
@@ -73770,7 +74045,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73797,7 +74072,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -73805,23 +74080,23 @@ aa
 aV
 ax
 ax
+aB
+ap
+ap
 aA
-ap
-ap
-ap
-bo
-bo
-bo
-ap
-bo
-bo
-bo
-bo
-bo
+aA
+bJ
+bM
+bM
+bP
+bS
+bM
+bY
+cb
 bo
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -73856,7 +74131,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (32,1,2) = {"
 aa
@@ -74027,7 +74302,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -74054,7 +74329,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -74062,14 +74337,14 @@ aa
 aV
 ax
 ax
+aB
+aB
+ap
 aA
 aA
-ap
-ap
-bo
-ap
-ap
-ap
+bK
+aA
+aA
 ap
 ap
 bo
@@ -74078,7 +74353,7 @@ bo
 ap
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -74113,7 +74388,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (33,1,2) = {"
 aa
@@ -74284,7 +74559,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -74311,7 +74586,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -74319,8 +74594,8 @@ aa
 aV
 ax
 ax
-aA
-aA
+aB
+aB
 ap
 ap
 ap
@@ -74335,7 +74610,7 @@ ap
 ap
 ap
 am
-aV
+aT
 ae
 ae
 ae
@@ -74370,7 +74645,7 @@ ai
 ai
 ae
 ae
-ae
+aZ
 "}
 (34,1,2) = {"
 aa
@@ -74541,39 +74816,39 @@ aa
 aa
 aa
 aa
+aT
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aT
+aa
+aa
+aa
+aa
 aV
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aV
-aa
-aa
-aa
-aa
-aV
 ax
 ax
 ax
@@ -74592,7 +74867,7 @@ ax
 am
 am
 am
-aV
+aT
 ae
 ae
 ae
@@ -74627,7 +74902,7 @@ ae
 ae
 ae
 ae
-ae
+aZ
 "}
 (35,1,2) = {"
 aa
@@ -74798,7 +75073,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -74825,7 +75100,7 @@ aa
 aa
 aa
 aa
-aV
+aT
 aa
 aa
 aa
@@ -74849,7 +75124,7 @@ ax
 am
 am
 am
-aV
+aT
 ae
 ae
 ae
@@ -74884,7 +75159,7 @@ ae
 ae
 ae
 ae
-ae
+aZ
 "}
 (36,1,2) = {"
 aa
@@ -75055,93 +75330,93 @@ aa
 aa
 aa
 aa
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aa
-aa
-aa
-aa
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-aV
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aW
+aW
+aW
+aW
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
 "}
 (37,1,2) = {"
 aa

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("torpedo casing", /obj/structure/torpedo_casing, 5, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("railing", /obj/structure/railing/built, 2, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("deck to deck power relay", /obj/machinery/power/deck_relay, 5, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe_list("office chairs", list( \
 		new/datum/stack_recipe("dark office chair", /obj/structure/chair/office/dark, 5, one_per_turf = TRUE, on_floor = TRUE), \


### PR DESCRIPTION
Borgs get some much needed TLC and a proper ruin which they can expand

![](https://cdn.discordapp.com/attachments/360877760580943873/565180294982926336/unknown.png)

Added a starfleet security spawn to the borg ship so they can call for help

Borg moon is now much more reasonable to investigate (BE GONE CAMPBELL).

A few map fixes here and there
You can also now make + move deck relays

:cl: Kmc2000 (with the borg queen)
fix: Borg ruin improved, borgs can now be deconverted by removing their borg nanites from their chest.
/:cl:

