### PR TITLE
Adds the two world topics for getting players and admins into discord.

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -181,3 +181,25 @@
 		.["shuttle_timer"] = SSshuttle.emergency.timeLeft()
 		// Shuttle timer, in seconds
 
+/datum/world_topic/whois
+	keyword = "whoIs"
+
+/datum/world_topic/whois/Run(list/input)
+	/var/list/s = list()
+	s["players"] = GLOB.clients
+
+	return list2params(s)
+
+/datum/world_topic/getadmins
+	keyword = "getAdmins"
+
+/datum/world_topic/getadmins/Run(list/input)
+	var/list/s = list()
+	var/list/adm = get_admin_counts()
+	var/list/presentmins = adm["present"]
+	var/list/afkmins = adm["afk"]
+	s["admins"] = presentmins
+	s["admins"] += afkmins
+
+	return list2params(s)	
+


### PR DESCRIPTION
Forgot to include this within my last PR #78 . This should enable the `players` and `adminwho` commands.