### PR TITLE
[Sovereign] Solving mining by tearing out the floor tiles.

### DIFF
--- a/_maps/map_files/Sovereign/Sovereign.dmm
+++ b/_maps/map_files/Sovereign/Sovereign.dmm
@@ -4003,6 +4003,13 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
+"lG" = (
+/obj/machinery/power/apc/auto_name/ds13/highcap,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
 "lH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	icon_state = "scrub_map_on-1";
@@ -4237,15 +4244,11 @@
 	},
 /area/quartermaster/storage)
 "mt" = (
-/obj/machinery/power/apc/auto_name/ds13/highcap,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/carpet/trek,
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "mu" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/carpet/trek,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "mv" = (
 /obj/machinery/door/airlock/trek/goon/external/public{
@@ -9788,6 +9791,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"Au" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
 "Av" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
@@ -11200,8 +11210,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "DX" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/carpet/trek,
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "DY" = (
 /obj/structure/janitorialcart,
@@ -11226,14 +11238,8 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
 "Eb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 10
-	},
-/turf/open/floor/carpet/trek,
+/obj/structure/closet/emcloset,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "Ec" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
@@ -11260,17 +11266,38 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/quartermaster/warehouse)
-"Eh" = (
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor";
-	name = "supply dock loading door"
+"Eg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
+"Eh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "Ei" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/trek/middle,
-/turf/open/floor/carpet/trek,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 10
+	},
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "Ej" = (
 /obj/machinery/conveyor{
@@ -12187,12 +12214,11 @@
 /turf/open/openspace,
 /area/hallway/primary/fore)
 "Gt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	icon_state = "scrub_map_on-1";
-	dir = 1
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "supply dock loading door"
 	},
-/obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/carpet/trek,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "Gu" = (
 /obj/machinery/conveyor{
@@ -12471,14 +12497,9 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
 "Hb" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/trek/goon/external/public{
-	icon_state = "closed";
-	dir = 8
-	},
-/turf/open/floor/carpet/trek,
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/trek/middle,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "Hc" = (
 /obj/structure/cable{
@@ -12491,14 +12512,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "Hd" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/trek/goon/external/public{
-	icon_state = "closed";
-	dir = 8
-	},
-/turf/open/floor/carpet/trek,
+/obj/structure/rack,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "He" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12622,11 +12637,12 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
 "Hr" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 2;
-	output_dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	icon_state = "scrub_map_on-1";
+	dir = 1
 	},
-/turf/open/floor/carpet/trek,
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "Hs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14011,6 +14027,16 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
+"Ky" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/trek/goon/external/public{
+	icon_state = "closed";
+	dir = 8
+	},
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
 "Kz" = (
 /obj/structure/trek_catwalk/cargo,
 /obj/machinery/light{
@@ -15968,29 +15994,34 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/miningdock)
 "Pw" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/trek/goon/external/public{
+	icon_state = "closed";
+	dir = 8
+	},
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
+"Px" = (
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 2;
+	output_dir = 1
+	},
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
+"Py" = (
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
+"Pz" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
-"Px" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/trek/middle,
-/turf/open/space/basic,
-/area/quartermaster/miningdock)
-"Py" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
-"Pz" = (
-/obj/structure/window/reinforced/fulltile/trek/middle,
-/obj/structure/grille,
-/turf/open/floor/carpet/trek,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "PA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16015,28 +16046,27 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/miningdock)
 "PB" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/carpet/trek,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "PC" = (
+/obj/structure/window/reinforced/fulltile/trek/middle,
+/obj/structure/grille,
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
+"PD" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/floor/fakespace,
+/area/quartermaster/miningdock)
+"PE" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/machinery/camera/trek{
 	icon_state = "camera";
 	dir = 1
 	},
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
-"PD" = (
-/obj/machinery/light,
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
-"PE" = (
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor";
-	name = "supply dock loading door"
-	},
-/turf/open/floor/carpet/trek,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "PF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16166,8 +16196,9 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/warehouse)
 "PV" = (
-/obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/carpet/trek,
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/fakespace,
 /area/quartermaster/miningdock)
 "PW" = (
 /obj/structure/trek_catwalk/cargo,
@@ -16384,19 +16415,6 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/hallway/primary/fore)
-"Qv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
 "Qw" = (
 /obj/structure/chair/trek/standard{
 	icon_state = "chair";
@@ -16421,16 +16439,6 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/hallway/primary/aft)
-"Qz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
 "QA" = (
 /obj/structure/chair/trek/standard{
 	icon_state = "chair";
@@ -16780,13 +16788,6 @@
 /obj/structure/trek_decor/rack,
 /turf/closed/wall/trek_smooth/room,
 /area/quartermaster/storage)
-"Rq" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
 "Rr" = (
 /obj/structure/overmap_component/viewscreen,
 /turf/closed/wall/trek_smooth/room,
@@ -16866,10 +16867,6 @@
 /obj/structure/overmap/runabout,
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
-"Ze" = (
-/obj/structure/rack,
-/turf/open/floor/carpet/trek,
-/area/quartermaster/miningdock)
 "ZA" = (
 /obj/machinery/shower{
 	dir = 4
@@ -181023,12 +181020,12 @@ PJ
 PJ
 PJ
 bO
-mt
-Qv
-Ze
-Hr
-hS
-hS
+lG
+Eg
+Hd
+Px
+mu
+mu
 bO
 sv
 sv
@@ -181280,12 +181277,12 @@ PJ
 hS
 PJ
 bO
+mt
+Eh
 mu
-Qz
-hS
-hS
-hS
-PB
+mu
+mu
+PD
 bO
 sv
 sv
@@ -181537,12 +181534,12 @@ hS
 Pi
 hS
 bO
-hS
-Qz
-hS
-hS
-hS
-hS
+mu
+Eh
+mu
+mu
+mu
+mu
 bO
 sv
 sv
@@ -181794,12 +181791,12 @@ PK
 PK
 hS
 Rr
-Rq
-Eb
-Gt
-PV
-PV
-PC
+Au
+Ei
+Hr
+Py
+Py
+PE
 bO
 sv
 sv
@@ -182051,12 +182048,12 @@ Ra
 PN
 hS
 bO
-FK
-hS
-hS
-hS
-hS
-hS
+DX
+mu
+mu
+mu
+mu
+mu
 bO
 sv
 sv
@@ -182308,12 +182305,12 @@ Rb
 Re
 hS
 bO
+mt
 mu
-hS
-hS
-Pw
-hS
-PD
+mu
+Pz
+mu
+PV
 bO
 sv
 sv
@@ -182566,11 +182563,11 @@ Qi
 hS
 bO
 bO
-Eh
+Gt
+Ky
 Hb
-Px
-Hb
-PE
+Ky
+Gt
 bO
 sv
 sv
@@ -182822,12 +182819,12 @@ Rc
 Rd
 hS
 bO
-DX
-hS
-hS
-Py
-hS
-hS
+Eb
+mu
+mu
+PB
+mu
+mu
 bO
 sv
 sv
@@ -183080,11 +183077,11 @@ bO
 bO
 bO
 bO
-Ei
-Hd
-Pz
-Hd
-Ei
+Hb
+Pw
+PC
+Pw
+Hb
 bO
 sv
 hG


### PR DESCRIPTION
[Changelogs]: I fixed the flooring in mining aboard the Sovereign.

add: more spacious flooring.
del: the hole to space beneath the northen blastdoor is no longer lonely and depressed.
balance: miners will be more challanged with their mission
fix: fixed cargo
soundadd: the screams of cargo mains
sounddel: the screams related to cargo having **ONE** hole
imageadd: dis: 
![Mining fix](https://user-images.githubusercontent.com/43185112/57378054-32101200-71a4-11e9-9707-e0a881db85f4.JPG)

spellcheck: who has time to spell check?
code: I am but a humble salesclown I don't know how to code.

[why]: I've heard people complain about cargo having one hole in mining. I took their issue to heart and made cargo symetrical by tearing out everyfloortile, hope this helps.
