### PR TITLE
Exports the round ID to the bot whenever a new round is started

### DIFF
--- a/code/controllers/subsystem/redbot.dm
+++ b/code/controllers/subsystem/redbot.dm
@@ -5,8 +5,9 @@ SUBSYSTEM_DEF(redbot)
 /datum/controller/subsystem/redbot/Initialize(timeofday)
 	var/comms_key = CONFIG_GET(string/comms_key)
 	var/bot_ip = CONFIG_GET(string/bot_ip)
+	var/round_id = GLOB.round_id
 	if(config && bot_ip)
-		var/query = "http://[bot_ip]/?serverStart=1&key=[comms_key]"
+		var/query = "http://[bot_ip]/?serverStart=1&roundID=[round_id]&key=[comms_key]"
 		world.Export(query)
 	return ..()
 


### PR DESCRIPTION
:cl: Crossedfall
add: Exports the round ID whenever the bot subsystem is initialized
/:cl:

[why]: # Allows the bot to display the current round ID in admin/new-round notifications. See https://github.com/crossedfall/crossed-cogs/commit/fe0248ab358e683d588d8655b85ba1d09bba5695 for the relevant changes to the status cog.