### PR TITLE
Adds the PALADIN law board to AI Uploads

### DIFF
--- a/_maps/map_files/Akira/Akira-decks.dmm
+++ b/_maps/map_files/Akira/Akira-decks.dmm
@@ -9501,6 +9501,7 @@
 /obj/item/aiModule/core/full/asimov,
 /obj/item/aiModule/core/freeformcore,
 /obj/item/aiModule/core/full/custom,
+/obj/item/aiModule/core/full/paladin,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "zj" = (

--- a/_maps/map_files/Sovereign/Sovereign.dmm
+++ b/_maps/map_files/Sovereign/Sovereign.dmm
@@ -3529,6 +3529,7 @@
 /obj/item/aiModule/core/full/asimov,
 /obj/item/aiModule/core/freeformcore,
 /obj/item/aiModule/core/full/custom,
+/obj/item/aiModule/core/full/paladin,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "kp" = (


### PR DESCRIPTION
:cl:
add: Adds PALADIN board to the Akira/Sovereign ships.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
We start off with Paladin lawset, so why not.