### PR TITLE
Misc fixes

### DIFF
--- a/DS13/code/modules/overmap/movement.dm
+++ b/DS13/code/modules/overmap/movement.dm
@@ -249,7 +249,7 @@
 	var/pixel_collision_size_x = I.Width()
 	var/pixel_collision_size_y = I.Height()
 	for(var/atom/e in obounds(src, real_pixel_x + x_to_move + pixel_collision_size_x/4, real_pixel_y + y_to_move + pixel_collision_size_y/4, real_pixel_x + x_to_move + -pixel_collision_size_x/4, real_pixel_y + y_to_move + -pixel_collision_size_x/4) )//Basic block collision
-		if(e.density == 1) //We can change this so the ship takes damage later
+		if(e.density)
 			if(ismob(e))
 				return //Ignore mobs. Prevents the glitchy runabout behaviour
 			if(istype(e, /obj/structure/meteor))
@@ -257,9 +257,13 @@
 				S.crash(src)
 				O.vel = 0
 			else
-				Bump(e)
-				if(!CanPass(src, e))
-					if(istype(src, /obj/structure/overmap) && isturf(e))
+				if(e.CanPass(src))
+					continue
+				else
+					if(!e.mouse_opacity) //Ignore any kind of blockers that aren't truly there
+						continue
+					Bump(e)
+					if(istype(src, /obj/structure/overmap))
 						O.vel = 0
 					return FALSE
 

--- a/DS13/code/modules/overmap/overmap.dm
+++ b/DS13/code/modules/overmap/overmap.dm
@@ -33,6 +33,12 @@ GLOBAL_LIST_INIT(overmap_ships, list())
 	var/max_warp = WARP_5
 	var/capture_in_progress = FALSE //Is someone trying to hijack the ship?
 
+/obj/structure/overmap/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /obj/structure/overmap)) //overmaps may pass other overmaps
+		return TRUE
+	else
+		. = ..()
+
 /obj/shield_overlay
 	name = ""
 	animate_movement = 0

--- a/DeepSpace13.dme
+++ b/DeepSpace13.dme
@@ -14,6 +14,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "_maps\Sovereign.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"

--- a/_maps/map_files/Akira/Akira-decks.dmm
+++ b/_maps/map_files/Akira/Akira-decks.dmm
@@ -3374,7 +3374,7 @@
 	icon_state = "chair";
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/offduty/engineer,
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/bar)
 "jN" = (
@@ -6812,26 +6812,31 @@
 /turf/closed/wall/trek_smooth/room,
 /area/crew_quarters/heads/captain)
 "sv" = (
-/obj/structure/table/trek,
 /obj/structure/chair/trek/standard,
 /obj/effect/landmark/start/head_of_security,
+/obj/structure/table/trek{
+	layer = 4.1
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "sw" = (
-/obj/structure/table/trek{
-	icon_state = "table1";
-	dir = 1
-	},
 /obj/structure/chair/trek/standard,
+/obj/effect/landmark/start/lawyer,
+/obj/structure/table/trek{
+	dir = 1;
+	icon_state = "table1";
+	layer = 4.1
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "sx" = (
-/obj/structure/table/trek{
-	icon_state = "table1";
-	dir = 4
-	},
 /obj/structure/chair/trek/standard,
 /obj/effect/landmark/start/research_director,
+/obj/structure/table/trek{
+	dir = 4;
+	icon_state = "table1";
+	layer = 4.1
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "sy" = (
@@ -6885,6 +6890,11 @@
 	icon_state = "table1";
 	dir = 5
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "sI" = (
@@ -6892,12 +6902,22 @@
 	icon_state = "table1-contd";
 	dir = 9
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "sJ" = (
 /obj/structure/table/trek{
 	icon_state = "table1";
 	dir = 9
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -6990,12 +7010,22 @@
 	icon_state = "table1";
 	dir = 8
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "sY" = (
 /obj/structure/table/trek{
 	icon_state = "table1";
 	dir = 6
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -7144,6 +7174,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "tt" = (
@@ -7154,6 +7189,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "tu" = (
@@ -7163,6 +7203,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -10716,6 +10761,7 @@
 	icon_state = "vent_map_on-1";
 	dir = 4
 	},
+/obj/effect/landmark/start/yeoman,
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/bar)
 "Cf" = (
@@ -12563,6 +12609,10 @@
 	},
 /turf/closed/wall/trek_smooth/room,
 /area/engine/atmos)
+"HW" = (
+/obj/effect/landmark/start/offduty/doctor,
+/turf/open/floor/carpet/trek,
+/area/crew_quarters/bar)
 "IE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -12865,6 +12915,10 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"PW" = (
+/obj/effect/landmark/start/offduty/sec,
+/turf/open/floor/carpet/trek,
+/area/crew_quarters/bar)
 "PY" = (
 /obj/machinery/door/airlock/trek/goon/engi{
 	icon_state = "closed";
@@ -13111,7 +13165,7 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Xy" = (
-/obj/effect/landmark/start/librarian,
+/obj/effect/landmark/start/offduty/bridge,
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/bar)
 "XD" = (
@@ -13119,11 +13173,11 @@
 	icon_state = "chair";
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
 /obj/machinery/camera/trek{
 	icon_state = "camera";
 	dir = 9
 	},
+/obj/effect/landmark/start/offduty/engineer,
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/bar)
 "XG" = (
@@ -13214,6 +13268,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"ZM" = (
+/obj/structure/chair/trek/standard{
+	icon_state = "chair";
+	dir = 1
+	},
+/obj/effect/landmark/start/offduty/doctor,
+/turf/open/floor/carpet/trek,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -107385,8 +107447,8 @@ iH
 iZ
 jg
 Ce
-jf
-jf
+PW
+PW
 Bl
 kL
 lm
@@ -108415,7 +108477,7 @@ jk
 jw
 jM
 jf
-jf
+HW
 kQ
 lm
 ll
@@ -108670,7 +108732,7 @@ iH
 BF
 jl
 jx
-jM
+ZM
 jf
 Xy
 kL
@@ -108929,7 +108991,7 @@ jX
 jt
 XD
 Cu
-jf
+Xy
 Jy
 lk
 ll

--- a/_maps/map_files/Sovereign/Sovereign.dmm
+++ b/_maps/map_files/Sovereign/Sovereign.dmm
@@ -981,7 +981,9 @@
 /turf/closed/wall/trek_smooth/room,
 /area/ai_monitored/turret_protected/ai)
 "dc" = (
-/obj/structure/table/trek,
+/obj/structure/table/trek{
+	layer = 4.1
+	},
 /obj/structure/chair/trek/standard,
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -1249,8 +1251,9 @@
 /area/crew_quarters/heads/captain)
 "dS" = (
 /obj/structure/table/trek{
+	dir = 1;
 	icon_state = "table1";
-	dir = 1
+	layer = 4.1
 	},
 /obj/structure/chair/trek/standard,
 /turf/open/floor/carpet/trek,
@@ -1548,6 +1551,7 @@
 	icon_state = "chair";
 	dir = 4
 	},
+/obj/effect/landmark/start/offduty/bridge,
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/bar)
 "eQ" = (
@@ -1580,8 +1584,9 @@
 /area/hydroponics)
 "eV" = (
 /obj/structure/table/trek{
+	dir = 4;
 	icon_state = "table1";
-	dir = 4
+	layer = 4.1
 	},
 /obj/structure/chair/trek/standard,
 /turf/open/floor/carpet/trek,
@@ -2017,6 +2022,11 @@
 	icon_state = "table1";
 	dir = 5
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "gg" = (
@@ -2236,6 +2246,11 @@
 	dir = 10;
 	icon_state = "desk"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek/romulan,
 /area/library)
 "gN" = (
@@ -2243,6 +2258,11 @@
 	density = 1
 	},
 /obj/item/pen,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek/romulan,
 /area/library)
 "gO" = (
@@ -2256,6 +2276,11 @@
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/drinks/britcup,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek/romulan,
 /area/library)
 "gP" = (
@@ -2438,6 +2463,11 @@
 /obj/structure/table/trek/continued{
 	icon_state = "table1-contd";
 	dir = 9
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -3697,11 +3727,21 @@
 	dir = 10;
 	icon_state = "desk"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/security/brig)
 "kI" = (
 /obj/structure/table/trek/desk{
 	density = 1
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/security/brig)
@@ -3724,6 +3764,11 @@
 /obj/item/paper_bin{
 	pixel_x = 1;
 	pixel_y = 9
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/security/brig)
@@ -8907,6 +8952,11 @@
 	dir = 10;
 	icon_state = "desk"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/science/research)
 "yj" = (
@@ -8914,6 +8964,11 @@
 	density = 1
 	},
 /obj/item/pen,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/science/research)
 "yk" = (
@@ -8927,6 +8982,11 @@
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/drinks/britcup,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/science/research)
 "yl" = (
@@ -9204,6 +9264,11 @@
 	dir = 10;
 	icon_state = "desk"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/medical/medbay/central)
 "yW" = (
@@ -9211,6 +9276,11 @@
 	density = 1
 	},
 /obj/item/pen,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/medical/medbay/central)
 "yX" = (
@@ -9224,6 +9294,11 @@
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/drinks/britcup,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/medical/medbay/central)
 "yY" = (
@@ -11363,6 +11438,11 @@
 	icon_state = "table1";
 	dir = 9
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "Et" = (
@@ -11414,6 +11494,11 @@
 	icon_state = "table1-contd";
 	dir = 4
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "Ey" = (
@@ -11421,12 +11506,22 @@
 	icon_state = "table1-contd";
 	dir = 8
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "Ez" = (
 /obj/structure/table/trek/continued{
 	icon_state = "table1-contd";
 	dir = 6
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -11628,11 +11723,21 @@
 	dir = 10;
 	icon_state = "desk"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/heads/captain)
 "Ff" = (
 /obj/structure/table/trek/desk{
 	density = 1
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/heads/captain)
@@ -11647,6 +11752,11 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/heads/captain)
 "Fh" = (
@@ -11655,11 +11765,21 @@
 	dir = 10;
 	icon_state = "desk"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/heads/hop)
 "Fi" = (
 /obj/structure/table/trek/desk{
 	density = 1
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/heads/hop)
@@ -11674,6 +11794,11 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/crew_quarters/heads/hop)
 "Fk" = (
@@ -13031,6 +13156,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
+	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "If" = (
@@ -13040,6 +13170,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -13277,6 +13412,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/barricade{
+	alpha = 0;
+	mouse_opacity = 0;
+	name = "stop climbing on my tables idiot"
 	},
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
@@ -13650,6 +13790,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "Ju" = (
@@ -13704,6 +13845,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/bridge_officer,
 /turf/open/floor/carpet/trek,
 /area/ship/bridge/akira)
 "JA" = (
@@ -16837,6 +16979,22 @@
 /obj/structure/overmap/runabout,
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
+"TB" = (
+/obj/structure/chair/trek{
+	icon_state = "comfy";
+	dir = 1
+	},
+/obj/effect/landmark/start/bridge_officer,
+/turf/open/floor/carpet/trek,
+/area/ship/bridge/akira)
+"TY" = (
+/obj/structure/chair/trek/standard{
+	icon_state = "chair";
+	dir = 8
+	},
+/obj/effect/landmark/start/offduty/doctor,
+/turf/open/floor/carpet/trek,
+/area/crew_quarters/bar)
 "Ug" = (
 /obj/structure/closet{
 	name = "Combadges"
@@ -16889,6 +17047,14 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/carpet/trek,
 /area/quartermaster/miningdock)
+"WY" = (
+/obj/structure/chair/trek/standard{
+	icon_state = "chair";
+	dir = 4
+	},
+/obj/effect/landmark/start/offduty/engineer,
+/turf/open/floor/carpet/trek,
+/area/crew_quarters/bar)
 "YN" = (
 /obj/machinery/door/airlock/trek/goon{
 	dir = 4;
@@ -16901,6 +17067,14 @@
 /obj/machinery/ore_silo,
 /turf/open/floor/carpet/trek,
 /area/science/research)
+"Zq" = (
+/obj/structure/chair/trek/standard{
+	icon_state = "chair";
+	dir = 8
+	},
+/obj/effect/landmark/start/offduty/sec,
+/turf/open/floor/carpet/trek,
+/area/crew_quarters/bar)
 "Zw" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -112858,8 +113032,8 @@ aa
 cd
 eu
 eo
-eP
-eP
+WY
+WY
 Bw
 fB
 eo
@@ -113886,8 +114060,8 @@ aa
 cd
 eo
 eo
-fw
-fw
+Zq
+Zq
 Bw
 fB
 eo
@@ -115942,8 +116116,8 @@ aa
 cd
 eo
 ew
-fw
-fw
+TY
+TY
 fB
 gY
 eo
@@ -244472,7 +244646,7 @@ ap
 ap
 aH
 aW
-bh
+TB
 MC
 bH
 cL


### PR DESCRIPTION
-Fixes the godawful movement on the clown's rc shuttle
-Fixes spawnpoints on sov. Akira and Sov now have actual tables.
-Major movement code refactor

:cl: Kmc2000
add: Fixed spawn points on the sovereign for bridge officers, as well as other misc mapping fixes
/:cl:

