### PR TITLE
Ai armor project

### DIFF
--- a/_maps/map_files/Intrepid/Intrepid.dmm
+++ b/_maps/map_files/Intrepid/Intrepid.dmm
@@ -3052,6 +3052,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "ik" = (
@@ -3075,7 +3076,7 @@
 "im" = (
 /obj/structure/trek_decor/ai_wall,
 /obj/structure/trek_decor/ai_wall/optronic,
-/turf/closed/wall/trek_smooth/voy,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "in" = (
 /obj/machinery/door/airlock/trek/ship/maint{
@@ -3094,6 +3095,7 @@
 	name = "Computer core"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "ip" = (
@@ -3724,7 +3726,7 @@
 /turf/open/floor/carpet/trek/voy,
 /area/hallway/primary/central)
 "jL" = (
-/turf/closed/wall/trek_smooth/voy,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "jM" = (
 /obj/machinery/door/airlock/trek/ship{
@@ -5690,6 +5692,7 @@
 "oM" = (
 /obj/structure/trek_catwalk,
 /obj/machinery/light,
+/obj/machinery/ai_slipper,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "oN" = (
@@ -5706,6 +5709,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "oP" = (
@@ -5717,7 +5721,7 @@
 /area/maintenance/starboard/fore)
 "oQ" = (
 /obj/structure/trek_decor/ai_wall,
-/turf/closed/wall/trek_smooth/voy,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "oR" = (
 /obj/structure/trek_catwalk,
@@ -5731,7 +5735,7 @@
 /area/vacant_room/office)
 "oS" = (
 /obj/structure/trek_decor/viewscreen,
-/turf/closed/wall/trek_smooth/voy,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "oT" = (
 /obj/structure/railing,
@@ -5753,6 +5757,7 @@
 /obj/machinery/door/airlock/trek/ship/command{
 	name = "Computer core"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "oW" = (
@@ -5818,6 +5823,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "pb" = (
@@ -6644,6 +6650,7 @@
 "qZ" = (
 /obj/structure/trek_catwalk,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "ra" = (
@@ -6933,13 +6940,11 @@
 /turf/open/floor/carpet/trek/voy,
 /area/hallway/secondary/command)
 "rD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/carpet/trek/voy,
 /area/hallway/secondary/entry)
 "rE" = (
@@ -6957,13 +6962,10 @@
 /area/hallway/secondary/entry)
 "rF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/carpet/trek/voy,
 /area/hallway/secondary/entry)
 "rG" = (
@@ -11473,6 +11475,14 @@
 	},
 /turf/open/floor/carpet/trek/voy,
 /area/hallway/primary/central)
+"Jx" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "JE" = (
 /obj/machinery/camera/trek{
 	icon_state = "camera";
@@ -11608,6 +11618,14 @@
 /obj/machinery/camera/trek,
 /turf/open/floor/carpet/trek/voy,
 /area/turbolift/tertiary)
+"Lr" = (
+/obj/structure/trek_catwalk,
+/obj/machinery/camera/trek,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "LC" = (
 /obj/structure/trek_decor/brig,
 /obj/structure/trek_decor/rack,
@@ -11725,6 +11743,12 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/trek_smooth/voy,
 /area/ship/engineering/akira)
+"Oz" = (
+/obj/structure/trek_catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/ai_slipper,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "OC" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/trek_smooth/voy,
@@ -11910,6 +11934,15 @@
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/trek_smooth/voy,
 /area/ship/engineering/akira)
+"Sd" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/ai_slipper,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "Se" = (
 /obj/machinery/camera/trek{
 	icon_state = "camera";
@@ -12098,6 +12131,11 @@
 	},
 /turf/open/floor/carpet/trek/voy,
 /area/bridge/meeting_room)
+"Yi" = (
+/obj/structure/trek_catwalk,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "Yl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	icon_state = "pipe11-2";
@@ -172910,9 +172948,9 @@ yU
 jL
 ov
 oD
-oD
+Jx
 oO
-oD
+Sd
 pa
 ij
 rD
@@ -173168,8 +173206,8 @@ jL
 jL
 oE
 oG
-oQ
-oE
+jL
+Lr
 oG
 im
 rE
@@ -173938,9 +173976,9 @@ el
 jL
 ox
 oG
-oG
+Yi
 oV
-oG
+Oz
 qZ
 io
 rF

--- a/_maps/map_files/Intrepid/Intrepid.dmm
+++ b/_maps/map_files/Intrepid/Intrepid.dmm
@@ -3045,14 +3045,16 @@
 /turf/open/space/basic,
 /area/space)
 "ij" = (
-/obj/machinery/door/airlock/trek/ship/command{
-	name = "Computer core"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "ik" = (
@@ -3091,11 +3093,13 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "io" = (
-/obj/machinery/door/airlock/trek/ship/command{
-	name = "Computer core"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "ip" = (
@@ -5703,13 +5707,15 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "oO" = (
-/obj/machinery/door/airlock/trek/ship/command{
-	name = "Computer core"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "oP" = (
@@ -5754,10 +5760,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oV" = (
-/obj/machinery/door/airlock/trek/ship/command{
-	name = "Computer core"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "oW" = (

--- a/_maps/map_files/Sovereign/Sovereign.dmm
+++ b/_maps/map_files/Sovereign/Sovereign.dmm
@@ -978,7 +978,7 @@
 /turf/closed/wall/trek_smooth/room,
 /area/maintenance/department/bridge)
 "db" = (
-/turf/closed/wall/trek_smooth/room,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "dc" = (
 /obj/structure/table/trek,
@@ -2925,6 +2925,10 @@
 "iJ" = (
 /obj/structure/trek_catwalk,
 /obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/ai_slipper,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "iK" = (
@@ -3004,18 +3008,23 @@
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
 "iU" = (
-/obj/machinery/door/airlock/trek/ship/command{
-	name = "Computer core"
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "iV" = (
 /obj/structure/trek_decor/ai_wall,
-/turf/closed/wall/trek_smooth/room,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "iW" = (
 /obj/structure/trek_decor/viewscreen,
-/turf/closed/wall/trek_smooth/room,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "iX" = (
 /obj/structure/table,
@@ -3708,7 +3717,7 @@
 "kJ" = (
 /obj/structure/trek_decor/ai_wall,
 /obj/structure/trek_decor/ai_wall/optronic,
-/turf/closed/wall/trek_smooth/room,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "kK" = (
 /obj/structure/bed,
@@ -3843,7 +3852,7 @@
 /area/engine/atmos)
 "lf" = (
 /obj/structure/overmap_component/system_control,
-/turf/closed/wall/trek_smooth/room,
+/turf/closed/wall/trek_smooth/reinforced,
 /area/ai_monitored/turret_protected/ai)
 "lg" = (
 /obj/machinery/light,
@@ -13568,6 +13577,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
 "Jn" = (
@@ -13579,11 +13591,13 @@
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
 "Jo" = (
-/obj/machinery/door/airlock/trek/ship/command{
-	name = "Computer core"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
 	},
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
@@ -16830,6 +16844,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/command)
+"Sy" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "SU" = (
 /obj/structure/trek_catwalk/cargo/pad{
 	icon_state = "3,8"
@@ -16838,6 +16862,13 @@
 /obj/structure/overmap/runabout,
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
+"Uf" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "Ug" = (
 /obj/structure/closet{
 	name = "Combadges"
@@ -16861,6 +16892,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"Ur" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/ai_slipper,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "UC" = (
 /obj/item/clothing/under/trek/neelix,
 /obj/item/clothing/under/trek/neelix,
@@ -16898,6 +16937,13 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/entry)
+"Zj" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "Zp" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/carpet/trek,
@@ -243981,9 +244027,9 @@ cX
 db
 Jc
 Jj
-Jj
+Sy
 Jo
-Jj
+Ur
 Jj
 Jo
 Pl
@@ -244238,7 +244284,7 @@ aS
 db
 db
 Mc
-eD
+Uf
 iV
 Mc
 eD
@@ -244752,7 +244798,7 @@ aS
 db
 db
 eD
-eD
+Uf
 iV
 eD
 eD
@@ -245009,13 +245055,13 @@ cX
 db
 Pp
 eD
-eD
+Zj
 iU
-eD
-eD
+Ur
+Jj
 iU
-aS
-aS
+Jp
+Jp
 Jm
 EK
 EG

--- a/_maps/map_files/Sovereign/Sovereign.dmm
+++ b/_maps/map_files/Sovereign/Sovereign.dmm
@@ -1692,6 +1692,9 @@
 	dir = 4
 	},
 /obj/structure/trek_catwalk,
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "fi" = (
@@ -3016,6 +3019,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "iV" = (
@@ -13554,6 +13558,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	icon_state = "scrub_map_on-1";
+	dir = 8
+	},
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
 "Jl" = (
@@ -13563,22 +13571,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/trek,
-/area/hallway/secondary/command)
-"Jm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	icon_state = "scrub_map_on-1";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
@@ -13599,28 +13591,26 @@
 	locked = 1;
 	name = "Computer Core"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "Jp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
 "Jq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	icon_state = "scrub_map_on-1";
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
 "Jr" = (
@@ -15886,6 +15876,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet/trek,
 /area/hallway/secondary/command)
 "Pm" = (
@@ -16830,6 +16822,45 @@
 	},
 /turf/open/floor/carpet/trek,
 /area/quartermaster/storage)
+"RC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	icon_state = "scrub_map_on-1";
+	dir = 4
+	},
+/turf/open/floor/carpet/trek,
+/area/hallway/secondary/command)
+"RE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
+"RQ" = (
+/obj/machinery/door/airlock/highsecurity{
+	icon = 'DS13/icons/obj/machinery/doors/command.dmi';
+	locked = 1;
+	name = "Computer Core"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "RU" = (
 /obj/machinery/shower{
 	dir = 4
@@ -16852,6 +16883,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "SU" = (
@@ -16898,6 +16930,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/ai_slipper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "UC" = (
@@ -16914,6 +16947,15 @@
 /obj/item/clothing/under/trek/cadet,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"Vz" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "Wm" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -16929,6 +16971,32 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/carpet/trek,
 /area/quartermaster/miningdock)
+"Xl" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/ai_slipper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
+"XG" = (
+/obj/structure/trek_catwalk,
+/obj/machinery/camera/trek,
+/obj/machinery/airalarm{
+	pixel_y = 26
+	},
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
+"Yt" = (
+/obj/structure/trek_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/trek/tile,
+/area/ai_monitored/turret_protected/ai)
 "YN" = (
 /obj/machinery/door/airlock/trek/goon{
 	dir = 4;
@@ -16942,6 +17010,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/trek/tile,
 /area/ai_monitored/turret_protected/ai)
 "Zp" = (
@@ -244030,8 +244099,8 @@ Jj
 Sy
 Jo
 Ur
-Jj
-Jo
+Yt
+RE
 Pl
 Jp
 Jq
@@ -244285,8 +244354,8 @@ db
 db
 Mc
 Uf
-iV
-Mc
+db
+XG
 eD
 kJ
 iB
@@ -244805,7 +244874,7 @@ eD
 kJ
 iY
 aS
-Jk
+RC
 Eu
 EN
 EP
@@ -245057,12 +245126,12 @@ Pp
 eD
 Zj
 iU
-Ur
-Jj
-iU
+Xl
+Vz
+RQ
 Jp
 Jp
-Jm
+Jq
 EK
 EG
 EG


### PR DESCRIPTION
Incoming Message from Fleet Command: All ships effective immediately. Engineering refit teams have been dispatched to your ships to retrofit them with upgraded security in the vicinity of the Computer cores. All crews are to comply with construction of the new reinforced structures to the best of their ability. Failure to comply will be punished by courts martial.

[Changelogs]: Below is what I did... all changes apply to the Intrepid AND Sovereign. 
-Changed out walls so they are reinforced walls
-Extends atmospherics into the AI upload/core rooms.
-Adds AI foam slippers to AI Upload and core rooms.
-Changes out doors with high security doors re-sprited to look like the old ones.

[why]: # Because AIs on the ships are too easy to subvert if you vaguely know what you're doing as an antag. They are high security areas, and yet have effectively little more defense than hydroponics.